### PR TITLE
feat(api): implementar endpoint para actualizar documentos (#10)

### DIFF
--- a/application/document_service.py
+++ b/application/document_service.py
@@ -12,6 +12,7 @@ class DocumentDTO:
 class DocumentRepository(Protocol):
     async def get_by_id(self, id: str) -> Optional[DocumentDTO]: ...
     async def get_all(self) -> list[DocumentDTO]: ...
+    async def update(self, id: str, text: Optional[str], checksum: Optional[str]) -> Optional[DocumentDTO]: ...
 
 
 async def get_document(id: str, repository: DocumentRepository) -> Optional[DocumentDTO]:
@@ -20,3 +21,12 @@ async def get_document(id: str, repository: DocumentRepository) -> Optional[Docu
 
 async def get_all_documents(repository: DocumentRepository) -> list[DocumentDTO]:
     return await repository.get_all()
+
+
+async def update_document(
+    id: str,
+    text: Optional[str],
+    checksum: Optional[str],
+    repository: DocumentRepository,
+) -> Optional[DocumentDTO]:
+    return await repository.update(id, text, checksum)

--- a/data/repository.py
+++ b/data/repository.py
@@ -14,3 +14,14 @@ class BeanieDocumentRepository:
     async def get_all(self) -> list[DocumentDTO]:
         docs = await ExtractedDocument.all().to_list()
         return [DocumentDTO(id=str(d.id), text=d.text, checksum=d.checksum) for d in docs]
+
+    async def update(self, id: str, text: Optional[str], checksum: Optional[str]) -> Optional[DocumentDTO]:
+        doc = await ExtractedDocument.get(id)
+        if doc is None:
+            return None
+        if text is not None:
+            doc.text = text
+        if checksum is not None:
+            doc.checksum = checksum
+        await doc.save()
+        return DocumentDTO(id=str(doc.id), text=doc.text, checksum=doc.checksum)

--- a/presentation/main.py
+++ b/presentation/main.py
@@ -1,18 +1,30 @@
-from typing import Annotated
+from typing import Annotated, Optional
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, UploadFile, File, Depends, HTTPException
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, model_validator
 
-from application.document_service import DocumentRepository, get_document, get_all_documents
+from application.document_service import DocumentRepository, get_document, get_all_documents, update_document
 from application.checksum import calculate_checksum, save_document_if_unique
 from application.exceptions import DuplicateDocumentError
-
 
 from application.pdf_extractor import extract_text_from_bytes
 from data.connection import get_database_connection
 from data.models import ExtractedDocument
 from data.repositories import MongoChecksumRepository
+
+
+class UpdateDocumentRequest(BaseModel):
+    text: Optional[str] = None
+    checksum: Optional[str] = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self) -> "UpdateDocumentRequest":
+        if self.text is None and self.checksum is None:
+            raise ValueError("At least one of 'text' or 'checksum' must be provided")
+        return self
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -39,7 +51,7 @@ def get_repository() -> MongoChecksumRepository:
 @app.get("/")
 async def root():
     return RedirectResponse(url="/docs")
-    
+
 @app.get("/health")
 async def health_check():
     return {"status": "ok", "message": "pong"}
@@ -69,6 +81,18 @@ async def list_documents(repo: Annotated[DocumentRepository, Depends(get_documen
 @app.get("/documents/{id}")
 async def read_document(id: str, repo: Annotated[DocumentRepository, Depends(get_document_repo)]):
     doc = await get_document(id, repo)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return {"id": doc.id, "text": doc.text, "checksum": doc.checksum}
+
+
+@app.patch("/documents/{id}")
+async def update_document_endpoint(
+    id: str,
+    body: UpdateDocumentRequest,
+    repo: Annotated[DocumentRepository, Depends(get_document_repo)],
+):
+    doc = await update_document(id, body.text, body.checksum, repo)
     if doc is None:
         raise HTTPException(status_code=404, detail="Document not found")
     return {"id": doc.id, "text": doc.text, "checksum": doc.checksum}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -81,3 +81,49 @@ async def test_list_all_documents_returns_200():
     ]
 
     app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_update_document_returns_200():
+    class MockRepo:
+        async def get_by_id(self, id: str) -> Optional[DocumentDTO]:
+            return DocumentDTO(id=id, text="original", checksum="old_hash")
+
+        async def get_all(self) -> list[DocumentDTO]:
+            return []
+
+        async def update(self, id: str, text: Optional[str], checksum: Optional[str]) -> Optional[DocumentDTO]:
+            return DocumentDTO(id=id, text=text or "original", checksum=checksum or "old_hash")
+
+    app.dependency_overrides[get_document_repo] = lambda: MockRepo()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.patch("/documents/abc123", json={"text": "updated text"})
+
+    assert response.status_code == 200
+    assert response.json() == {"id": "abc123", "text": "updated text", "checksum": "old_hash"}
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_update_document_returns_404_when_not_found():
+    class MockRepo:
+        async def get_by_id(self, id: str) -> Optional[DocumentDTO]:
+            return None
+
+        async def get_all(self) -> list[DocumentDTO]:
+            return []
+
+        async def update(self, id: str, text: Optional[str], checksum: Optional[str]) -> Optional[DocumentDTO]:
+            return None
+
+    app.dependency_overrides[get_document_repo] = lambda: MockRepo()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.patch("/documents/nonexistent", json={"text": "updated text"})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Document not found"}
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Descripción

Implementa `PATCH /documents/{id}` para modificar el texto y/o metadatos
(checksum) de un documento previamente persistido, siguiendo la
arquitectura limpia del proyecto.

## Cambios

- `presentation/main.py` — Agrega la ruta `PATCH /documents/{id}` y el
  modelo Pydantic `UpdateDocumentRequest` (validación: al menos un campo requerido)
- `application/document_service.py` — Extiende el `DocumentRepository`
  Protocol con `update()` y agrega la función de servicio `update_document()`
- `data/repository.py` — Implementa `update()` en `BeanieDocumentRepository`
  usando Beanie ODM

## Comportamiento

- `PATCH /documents/{id}` acepta `{"text": "..."}`, `{"checksum": "..."}` o ambos
- Responde `200` con el documento actualizado `{"id", "text", "checksum"}`
- Responde `404` si el documento no existe
- Responde `422` si el body no incluye ningún campo

## Test Plan

- [x] `test_update_document_returns_200` — actualización exitosa devuelve 200
- [x] `test_update_document_returns_404_when_not_found` — documento inexistente devuelve 404