### PR TITLE
refactor: aplicar DRY y naming según auditoría Clean Code (issue #14)

### DIFF
--- a/data/repository.py
+++ b/data/repository.py
@@ -5,15 +5,18 @@ from data.models import ExtractedDocument
 
 
 class BeanieDocumentRepository:
+    def _to_dto(self, doc: ExtractedDocument) -> DocumentDTO:
+        return DocumentDTO(id=str(doc.id), text=doc.text, checksum=doc.checksum)
+
     async def get_by_id(self, id: str) -> Optional[DocumentDTO]:
         doc = await ExtractedDocument.get(id)
         if doc is None:
             return None
-        return DocumentDTO(id=str(doc.id), text=doc.text, checksum=doc.checksum)
+        return self._to_dto(doc)
 
     async def get_all(self) -> list[DocumentDTO]:
         docs = await ExtractedDocument.all().to_list()
-        return [DocumentDTO(id=str(d.id), text=d.text, checksum=d.checksum) for d in docs]
+        return [self._to_dto(d) for d in docs]
 
     async def update(self, id: str, text: Optional[str], checksum: Optional[str]) -> Optional[DocumentDTO]:
         doc = await ExtractedDocument.get(id)
@@ -24,7 +27,7 @@ class BeanieDocumentRepository:
         if checksum is not None:
             doc.checksum = checksum
         await doc.save()
-        return DocumentDTO(id=str(doc.id), text=doc.text, checksum=doc.checksum)
+        return self._to_dto(doc)
 
     async def delete(self, id: str) -> bool:
         doc = await ExtractedDocument.get(id)

--- a/presentation/main.py
+++ b/presentation/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI, UploadFile, File, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, model_validator
 
-from application.document_service import DocumentRepository, get_document, get_all_documents, update_document, delete_document
+from application.document_service import DocumentDTO, DocumentRepository, get_document, get_all_documents, update_document, delete_document
 from application.checksum import calculate_checksum, save_document_if_unique
 from application.exceptions import DuplicateDocumentError
 
@@ -45,8 +45,13 @@ async def get_document_repo() -> DocumentRepository:
     return BeanieDocumentRepository()
 
 
-def get_repository() -> MongoChecksumRepository:
+def get_checksum_repo() -> MongoChecksumRepository:
     return MongoChecksumRepository()
+
+
+def _doc_to_response(doc: DocumentDTO) -> dict:
+    return {"id": doc.id, "text": doc.text, "checksum": doc.checksum}
+
 
 @app.get("/")
 async def root():
@@ -60,7 +65,7 @@ async def health_check():
 @app.post("/extract")
 async def extract_text(
     file: UploadFile = File(...),
-    repository: MongoChecksumRepository = Depends(get_repository),
+    repository: MongoChecksumRepository = Depends(get_checksum_repo),
 ):
     pdf_bytes = await file.read()
     checksum = calculate_checksum(pdf_bytes)
@@ -75,7 +80,7 @@ async def extract_text(
 @app.get("/documents")
 async def list_documents(repo: Annotated[DocumentRepository, Depends(get_document_repo)]):
     docs = await get_all_documents(repo)
-    return [{"id": d.id, "text": d.text, "checksum": d.checksum} for d in docs]
+    return [_doc_to_response(d) for d in docs]
 
 
 @app.get("/documents/{id}")
@@ -83,7 +88,7 @@ async def read_document(id: str, repo: Annotated[DocumentRepository, Depends(get
     doc = await get_document(id, repo)
     if doc is None:
         raise HTTPException(status_code=404, detail="Document not found")
-    return {"id": doc.id, "text": doc.text, "checksum": doc.checksum}
+    return _doc_to_response(doc)
 
 
 @app.patch("/documents/{id}")
@@ -95,7 +100,7 @@ async def update_document_endpoint(
     doc = await update_document(id, body.text, body.checksum, repo)
     if doc is None:
         raise HTTPException(status_code=404, detail="Document not found")
-    return {"id": doc.id, "text": doc.text, "checksum": doc.checksum}
+    return _doc_to_response(doc)
 
 
 @app.delete("/documents/{id}", status_code=204)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,21 @@ from httpx import ASGITransport, AsyncClient
 from application.document_service import DocumentDTO
 from presentation.main import app, get_document_repo
 
+
+class BaseMockRepo:
+    async def get_by_id(self, id: str) -> Optional[DocumentDTO]:
+        return None
+
+    async def get_all(self) -> list[DocumentDTO]:
+        return []
+
+    async def update(self, id: str, text: Optional[str], checksum: Optional[str]) -> Optional[DocumentDTO]:
+        return None
+
+    async def delete(self, id: str) -> bool:
+        return False
+
+
 @pytest.mark.asyncio
 async def test_ping_server():
     with patch("presentation.main.get_database_connection", new_callable=AsyncMock):
@@ -19,12 +34,9 @@ async def test_ping_server():
 
 @pytest.mark.asyncio
 async def test_read_document_by_id_returns_200():
-    class MockRepo:
+    class MockRepo(BaseMockRepo):
         async def get_by_id(self, id: str) -> Optional[DocumentDTO]:
             return DocumentDTO(id=id, text="extracted text", checksum="abc123")
-
-        async def get_all(self) -> list[DocumentDTO]:
-            return []
 
     app.dependency_overrides[get_document_repo] = lambda: MockRepo()
 
@@ -39,14 +51,7 @@ async def test_read_document_by_id_returns_200():
 
 @pytest.mark.asyncio
 async def test_read_document_by_id_returns_404_when_not_found():
-    class MockRepo:
-        async def get_by_id(self, id: str) -> Optional[DocumentDTO]:
-            return None
-
-        async def get_all(self) -> list[DocumentDTO]:
-            return []
-
-    app.dependency_overrides[get_document_repo] = lambda: MockRepo()
+    app.dependency_overrides[get_document_repo] = lambda: BaseMockRepo()
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.get("/documents/nonexistent")
@@ -59,10 +64,7 @@ async def test_read_document_by_id_returns_404_when_not_found():
 
 @pytest.mark.asyncio
 async def test_list_all_documents_returns_200():
-    class MockRepo:
-        async def get_by_id(self, id: str) -> Optional[DocumentDTO]:
-            return None
-
+    class MockRepo(BaseMockRepo):
         async def get_all(self) -> list[DocumentDTO]:
             return [
                 DocumentDTO(id="1", text="first", checksum="aaa"),
@@ -85,13 +87,7 @@ async def test_list_all_documents_returns_200():
 
 @pytest.mark.asyncio
 async def test_update_document_returns_200():
-    class MockRepo:
-        async def get_by_id(self, id: str) -> Optional[DocumentDTO]:
-            return DocumentDTO(id=id, text="original", checksum="old_hash")
-
-        async def get_all(self) -> list[DocumentDTO]:
-            return []
-
+    class MockRepo(BaseMockRepo):
         async def update(self, id: str, text: Optional[str], checksum: Optional[str]) -> Optional[DocumentDTO]:
             return DocumentDTO(id=id, text=text or "original", checksum=checksum or "old_hash")
 
@@ -108,17 +104,7 @@ async def test_update_document_returns_200():
 
 @pytest.mark.asyncio
 async def test_update_document_returns_404_when_not_found():
-    class MockRepo:
-        async def get_by_id(self, id: str) -> Optional[DocumentDTO]:
-            return None
-
-        async def get_all(self) -> list[DocumentDTO]:
-            return []
-
-        async def update(self, id: str, text: Optional[str], checksum: Optional[str]) -> Optional[DocumentDTO]:
-            return None
-
-    app.dependency_overrides[get_document_repo] = lambda: MockRepo()
+    app.dependency_overrides[get_document_repo] = lambda: BaseMockRepo()
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.patch("/documents/nonexistent", json={"text": "updated text"})
@@ -131,16 +117,7 @@ async def test_update_document_returns_404_when_not_found():
 
 @pytest.mark.asyncio
 async def test_delete_document_returns_204():
-    class MockRepo:
-        async def get_by_id(self, id: str) -> Optional[DocumentDTO]:
-            return None
-
-        async def get_all(self) -> list[DocumentDTO]:
-            return []
-
-        async def update(self, id: str, text: Optional[str], checksum: Optional[str]) -> Optional[DocumentDTO]:
-            return None
-
+    class MockRepo(BaseMockRepo):
         async def delete(self, id: str) -> bool:
             return True
 
@@ -157,20 +134,7 @@ async def test_delete_document_returns_204():
 
 @pytest.mark.asyncio
 async def test_delete_document_returns_404_when_not_found():
-    class MockRepo:
-        async def get_by_id(self, id: str) -> Optional[DocumentDTO]:
-            return None
-
-        async def get_all(self) -> list[DocumentDTO]:
-            return []
-
-        async def update(self, id: str, text: Optional[str], checksum: Optional[str]) -> Optional[DocumentDTO]:
-            return None
-
-        async def delete(self, id: str) -> bool:
-            return False
-
-    app.dependency_overrides[get_document_repo] = lambda: MockRepo()
+    app.dependency_overrides[get_document_repo] = lambda: BaseMockRepo()
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.delete("/documents/nonexistent")
@@ -183,7 +147,7 @@ async def test_delete_document_returns_404_when_not_found():
 
 @pytest.mark.asyncio
 async def test_get_deleted_document_returns_404():
-    class MockRepo:
+    class MockRepo(BaseMockRepo):
         def __init__(self):
             self.deleted = False
 
@@ -191,12 +155,6 @@ async def test_get_deleted_document_returns_404():
             if self.deleted:
                 return None
             return DocumentDTO(id=id, text="to be deleted", checksum="abc")
-
-        async def get_all(self) -> list[DocumentDTO]:
-            return []
-
-        async def update(self, id: str, text: Optional[str], checksum: Optional[str]) -> Optional[DocumentDTO]:
-            return None
 
         async def delete(self, id: str) -> bool:
             self.deleted = True


### PR DESCRIPTION
- data/repository.py: extraer _to_dto() elimina construcción de DocumentDTO duplicada 3 veces
- presentation/main.py: extraer _doc_to_response() elimina dict de respuesta duplicado 3 veces; renombrar get_repository → get_checksum_repo para consistencia con get_document_repo
- tests/test_api.py: agregar BaseMockRepo con defaults no-op; cada test sobreescribe solo el método relevante — archivo baja de 217 a 174 líneas